### PR TITLE
Add EmailOTP verify API endpoint

### DIFF
--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/EmailotpApi.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/EmailotpApi.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPGenerateResponse
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPGenerationRequest;
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPValidationRequest;
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPValidationResponse;
+import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationRequest;
+import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationResponse;
 import org.wso2.carbon.identity.api.otp.service.emailotp.EmailotpApiService;
 
 import javax.validation.Valid;
@@ -90,6 +92,29 @@ public class EmailotpApi  {
     public Response emailotpValidatePost(@ApiParam(value = "" ,required=true) @Valid OTPValidationRequest otPValidationRequest) {
 
         return delegate.emailotpValidatePost(otPValidationRequest );
+    }
+
+    @Valid
+    @POST
+    @Path("/verify")
+    @Consumes({ "application/json" })
+    @Produces({ "application/json" })
+    @ApiOperation(value = "", notes = "This API is used to verify the emailotp without invalidate. <b>Permission required:</b><br> * none<br> <b>Scope required:</b><br> * internal_login ", response = OTPVerificationResponse.class, authorizations = {
+        @Authorization(value = "BasicAuth"),
+        @Authorization(value = "OAuth2", scopes = {
+            
+        })
+    }, tags={ "emailotp" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "OK", response = OTPVerificationResponse.class),
+        @ApiResponse(code = 400, message = "Bad Request", response = Error.class),
+        @ApiResponse(code = 401, message = "Unauthorized", response = Void.class),
+        @ApiResponse(code = 403, message = "Resource Forbidden", response = Void.class),
+        @ApiResponse(code = 500, message = "Server Error", response = Error.class)
+    })
+    public Response emailotpVerifyPost(@ApiParam(value = "" ,required=true) @Valid OTPVerificationRequest otPVerificationRequest) {
+
+        return delegate.emailotpVerifyPost(otPVerificationRequest );
     }
 
 }

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/EmailotpApiService.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/EmailotpApiService.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPGenerateResponse
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPGenerationRequest;
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPValidationRequest;
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPValidationResponse;
+import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationRequest;
+import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationResponse;
 import javax.ws.rs.core.Response;
 
 
@@ -37,4 +39,6 @@ public interface EmailotpApiService {
       public Response emailotpGeneratePost(OTPGenerationRequest otPGenerationRequest);
 
       public Response emailotpValidatePost(OTPValidationRequest otPValidationRequest);
+
+      public Response emailotpVerifyPost(OTPVerificationRequest otPVerificationRequest);
 }

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationFailureReason.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationFailureReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationFailureReason.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationFailureReason.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationFailureReason.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationFailureReason.java
@@ -19,17 +19,10 @@
 package org.wso2.carbon.identity.api.otp.service.emailotp.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import javax.validation.constraints.*;
 
-
-import io.swagger.annotations.*;
 import java.util.Objects;
 import javax.validation.Valid;
-import javax.xml.bind.annotation.*;
-
 public class OTPVerificationFailureReason  {
   
     private String code;

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationFailureReason.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationFailureReason.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.otp.service.emailotp.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OTPVerificationFailureReason  {
+  
+    private String code;
+    private String message;
+    private String description;
+
+    /**
+    **/
+    public OTPVerificationFailureReason code(String code) {
+
+        this.code = code;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "EMAIL-60006", value = "")
+    @JsonProperty("code")
+    @Valid
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    /**
+    * OTP verification failure reason.
+    **/
+    public OTPVerificationFailureReason message(String message) {
+
+        this.message = message;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Expired OTP.", value = "OTP verification failure reason.")
+    @JsonProperty("message")
+    @Valid
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
+    * OTP verification failure reason description.
+    **/
+    public OTPVerificationFailureReason description(String description) {
+
+        this.description = description;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "Expired OTP provided for the user Id: 8b1cc9c4-b671-448a-a334-5afe838a4a3b.", value = "OTP verification failure reason description.")
+    @JsonProperty("description")
+    @Valid
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OTPVerificationFailureReason otPVerificationFailureReason = (OTPVerificationFailureReason) o;
+        return Objects.equals(this.code, otPVerificationFailureReason.code) &&
+            Objects.equals(this.message, otPVerificationFailureReason.message) &&
+            Objects.equals(this.description, otPVerificationFailureReason.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, message, description);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OTPVerificationFailureReason {\n");
+        
+        sb.append("    code: ").append(toIndentedString(code)).append("\n");
+        sb.append("    message: ").append(toIndentedString(message)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationRequest.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationRequest.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationRequest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationRequest.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationRequest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.otp.service.emailotp.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OTPVerificationRequest  {
+  
+    private String userId;
+    private String transactionId;
+    private String emailOtp;
+
+    /**
+    * SCIM ID of the user
+    **/
+    public OTPVerificationRequest userId(String userId) {
+
+        this.userId = userId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "8b1cc9c4-b671-448a-a334-5afe838a4a3b", value = "SCIM ID of the user")
+    @JsonProperty("userId")
+    @Valid
+    public String getUserId() {
+        return userId;
+    }
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    /**
+    * Unique identifier of the generated OTP
+    **/
+    public OTPVerificationRequest transactionId(String transactionId) {
+
+        this.transactionId = transactionId;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "Unique identifier of the generated OTP")
+    @JsonProperty("transactionId")
+    @Valid
+    public String getTransactionId() {
+        return transactionId;
+    }
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    /**
+    * EMAIL OTP
+    **/
+    public OTPVerificationRequest emailOtp(String emailOtp) {
+
+        this.emailOtp = emailOtp;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "EMAIL OTP")
+    @JsonProperty("emailOtp")
+    @Valid
+    public String getEmailOtp() {
+        return emailOtp;
+    }
+    public void setEmailOtp(String emailOtp) {
+        this.emailOtp = emailOtp;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OTPVerificationRequest otPVerificationRequest = (OTPVerificationRequest) o;
+        return Objects.equals(this.userId, otPVerificationRequest.userId) &&
+            Objects.equals(this.transactionId, otPVerificationRequest.transactionId) &&
+            Objects.equals(this.emailOtp, otPVerificationRequest.emailOtp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, transactionId, emailOtp);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OTPVerificationRequest {\n");
+        
+        sb.append("    userId: ").append(toIndentedString(userId)).append("\n");
+        sb.append("    transactionId: ").append(toIndentedString(transactionId)).append("\n");
+        sb.append("    emailOtp: ").append(toIndentedString(emailOtp)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationResponse.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationResponse.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationResponse.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationResponse.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationResponse.java
@@ -18,19 +18,15 @@
 
 package org.wso2.carbon.identity.api.otp.service.emailotp.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationFailureReason;
-import javax.validation.constraints.*;
 
-
-import io.swagger.annotations.*;
 import java.util.Objects;
 import javax.validation.Valid;
-import javax.xml.bind.annotation.*;
+import javax.validation.constraints.NotNull;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class OTPVerificationResponse  {
   
     private Boolean isValid;

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationResponse.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/gen/java/org/wso2/carbon/identity/api/otp/service/emailotp/dto/OTPVerificationResponse.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.api.otp.service.emailotp.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationFailureReason;
+import javax.validation.constraints.*;
+
+
+import io.swagger.annotations.*;
+import java.util.Objects;
+import javax.validation.Valid;
+import javax.xml.bind.annotation.*;
+
+public class OTPVerificationResponse  {
+  
+    private Boolean isValid;
+    private String userId;
+    private OTPVerificationFailureReason failureReason;
+
+    /**
+    * EMAIL OTP verified successfully
+    **/
+    public OTPVerificationResponse isValid(Boolean isValid) {
+
+        this.isValid = isValid;
+        return this;
+    }
+    
+    @ApiModelProperty(required = true, value = "EMAIL OTP verified successfully")
+    @JsonProperty("isValid")
+    @Valid
+    @NotNull(message = "Property isValid cannot be null.")
+
+    public Boolean getIsValid() {
+        return isValid;
+    }
+    public void setIsValid(Boolean isValid) {
+        this.isValid = isValid;
+    }
+
+    /**
+    * SCIM ID of the user which the token issued and verified
+    **/
+    public OTPVerificationResponse userId(String userId) {
+
+        this.userId = userId;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "8b1cc9c4-b671-448a-a334-5afe838a4a3b", required = true, value = "SCIM ID of the user which the token issued and verified")
+    @JsonProperty("userId")
+    @Valid
+    @NotNull(message = "Property userId cannot be null.")
+
+    public String getUserId() {
+        return userId;
+    }
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    /**
+    **/
+    public OTPVerificationResponse failureReason(OTPVerificationFailureReason failureReason) {
+
+        this.failureReason = failureReason;
+        return this;
+    }
+    
+    @ApiModelProperty(value = "")
+    @JsonProperty("failureReason")
+    @Valid
+    public OTPVerificationFailureReason getFailureReason() {
+        return failureReason;
+    }
+    public void setFailureReason(OTPVerificationFailureReason failureReason) {
+        this.failureReason = failureReason;
+    }
+
+
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OTPVerificationResponse otPVerificationResponse = (OTPVerificationResponse) o;
+        return Objects.equals(this.isValid, otPVerificationResponse.isValid) &&
+            Objects.equals(this.userId, otPVerificationResponse.userId) &&
+            Objects.equals(this.failureReason, otPVerificationResponse.failureReason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isValid, userId, failureReason);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("class OTPVerificationResponse {\n");
+        
+        sb.append("    isValid: ").append(toIndentedString(isValid)).append("\n");
+        sb.append("    userId: ").append(toIndentedString(userId)).append("\n");
+        sb.append("    failureReason: ").append(toIndentedString(failureReason)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+    * Convert the given object to string with each line indented by 4 spaces
+    * (except the first line).
+    */
+    private String toIndentedString(java.lang.Object o) {
+
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n");
+    }
+}
+

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/main/java/org/wso2/carbon/identity/api/otp/service/emailotp/impl/EmailotpApiServiceImpl.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/main/java/org/wso2/carbon/identity/api/otp/service/emailotp/impl/EmailotpApiServiceImpl.java
@@ -32,6 +32,9 @@ import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPGenerationReques
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPValidationFailureReason;
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPValidationRequest;
 import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPValidationResponse;
+import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationFailureReason;
+import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationRequest;
+import org.wso2.carbon.identity.api.otp.service.emailotp.dto.OTPVerificationResponse;
 import org.wso2.carbon.identity.api.otp.service.emailotp.util.EndpointUtils;
 
 import javax.ws.rs.core.Response;
@@ -95,6 +98,44 @@ public class EmailotpApiServiceImpl implements EmailotpApiService {
                         .description(failureReasonDTO.getDescription());
             }
             OTPValidationResponse response = new OTPValidationResponse()
+                    .isValid(responseDTO.isValid())
+                    .userId(responseDTO.getUserId())
+                    .failureReason(failureReason);
+            return Response.ok(response).build();
+        } catch (EmailOtpClientException e) {
+            return EndpointUtils.handleBadRequestResponse(e, log);
+        } catch (EmailOtpException e) {
+            return EndpointUtils.handleServerErrorResponse(e, log);
+        } catch (Throwable e) {
+            return EndpointUtils.handleUnexpectedServerError(e, log);
+        }
+    }
+
+    /**
+     * This method is implemented from org.wso2.carbon.identity.api.otp.service.emailotp.EmailotpApi
+     * to verify OTP without invalidate.
+     *
+     * @param otpVerificationRequest Otp verification request object.
+     * @return Response
+     */
+    @Override
+    public Response emailotpVerifyPost(OTPVerificationRequest otpVerificationRequest) {
+
+        String transactionId = StringUtils.trim(otpVerificationRequest.getTransactionId());
+        String userId = StringUtils.trim(otpVerificationRequest.getUserId());
+        String emailOtp = StringUtils.trim(otpVerificationRequest.getEmailOtp());
+        try {
+            ValidationResponseDTO responseDTO = EndpointUtils.getEmailOTPService().verifyEmailOTP(
+                    transactionId, userId, emailOtp);
+            FailureReasonDTO failureReasonDTO = responseDTO.getFailureReason();
+            OTPVerificationFailureReason failureReason = null;
+            if (failureReasonDTO != null) {
+                failureReason = new OTPVerificationFailureReason()
+                        .code(failureReasonDTO.getCode())
+                        .message(failureReasonDTO.getMessage())
+                        .description(failureReasonDTO.getDescription());
+            }
+            OTPVerificationResponse response = new OTPVerificationResponse()
                     .isValid(responseDTO.isValid())
                     .userId(responseDTO.getUserId())
                     .failureReason(failureReason);

--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/main/resources/email-otp.yaml
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/main/resources/email-otp.yaml
@@ -66,6 +66,45 @@ paths:
                 $ref: '#/components/schemas/Error'
       tags:
         - emailotp
+  /emailotp/verify:
+    post:
+      description: |
+        This API is used to verify the emailotp without invalidate.
+        <b>Permission required:</b><br>
+        * none<br>
+        <b>Scope required:</b><br>
+        * internal_login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OTPVerificationRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OTPVerificationResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Resource Forbidden
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      tags:
+        - emailotp
   /emailotp/validate:
     post:
       description: |
@@ -166,6 +205,60 @@ components:
           readOnly: true
           description: The generated OTP
 
+    #-----------------------------------------------------
+    # OTP Verification Request object
+    #-----------------------------------------------------
+    OTPVerificationRequest:
+      type: object
+      properties:
+        userId:
+          type: string
+          description: SCIM ID of the user
+          example: '8b1cc9c4-b671-448a-a334-5afe838a4a3b'
+        transactionId:
+          type: string
+          description: Unique identifier of the generated OTP
+        emailOtp:
+          type: string
+          description: EMAIL OTP
+
+    #-----------------------------------------------------
+    # OTP Verification Response object
+    #-----------------------------------------------------
+    OTPVerificationResponse:
+      type: object
+      required:
+        - isValid
+        - userId
+      properties:
+        isValid:
+          type: boolean
+          description: EMAIL OTP verified successfully
+        userId:
+          type: string
+          description: SCIM ID of the user which the token issued and verified
+          example: '8b1cc9c4-b671-448a-a334-5afe838a4a3b'
+        failureReason:
+          type: object
+          $ref: '#/components/schemas/OTPVerificationFailureReason'
+
+    #-----------------------------------------------------
+    # OTP Verification Failure Reason object
+    #-----------------------------------------------------
+    OTPVerificationFailureReason:
+      type: object
+      properties:
+        code:
+          type: string
+          example: EMAIL-60006
+        message:
+          type: string
+          description: OTP verification failure reason.
+          example: 'Expired OTP.'
+        description:
+          type: string
+          description: OTP verification failure reason description.
+          example: 'Expired OTP provided for the user Id: 8b1cc9c4-b671-448a-a334-5afe838a4a3b.'
     #-----------------------------------------------------
     # OTP Validation Request object
     #-----------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         <!-- otp extension properties -->
         <org.wso2.carbon.extension.identity.smsotp.common.version>3.0.15
         </org.wso2.carbon.extension.identity.smsotp.common.version>
-        <org.wso2.carbon.extension.identity.emailotp.common.version>4.0.10
+        <org.wso2.carbon.extension.identity.emailotp.common.version>4.0.9
         </org.wso2.carbon.extension.identity.emailotp.common.version>
 
         <!-- Carbon kernel version -->

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         <!-- otp extension properties -->
         <org.wso2.carbon.extension.identity.smsotp.common.version>3.0.15
         </org.wso2.carbon.extension.identity.smsotp.common.version>
-        <org.wso2.carbon.extension.identity.emailotp.common.version>4.0.6
+        <org.wso2.carbon.extension.identity.emailotp.common.version>4.0.9
         </org.wso2.carbon.extension.identity.emailotp.common.version>
 
         <!-- Carbon kernel version -->

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         <!-- otp extension properties -->
         <org.wso2.carbon.extension.identity.smsotp.common.version>3.0.15
         </org.wso2.carbon.extension.identity.smsotp.common.version>
-        <org.wso2.carbon.extension.identity.emailotp.common.version>4.0.9
+        <org.wso2.carbon.extension.identity.emailotp.common.version>4.0.10
         </org.wso2.carbon.extension.identity.emailotp.common.version>
 
         <!-- Carbon kernel version -->


### PR DESCRIPTION
Git Issue: https://github.com/wso2/product-is/issues/13788
Depends on https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/130
## Purpose
> To expose a REST API endpoint for the Email OTP verify without invalidate 

