### PR TITLE
Change log4j imports to slf4j

### DIFF
--- a/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/main/java/org/wso2/carbon/identity/api/otp/service/emailotp/util/EndpointUtils.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.emailotp/src/main/java/org/wso2/carbon/identity/api/otp/service/emailotp/util/EndpointUtils.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.identity.api.otp.service.emailotp.util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.log4j.MDC;
+import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.extension.identity.emailotp.common.EmailOtpService;
 import org.wso2.carbon.extension.identity.emailotp.common.constant.Constants;

--- a/component/org.wso2.carbon.identity.api.otp.service.smsotp/src/main/java/org/wso2/carbon/identity/api/otp/service/smsotp/utill/EndpointUtils.java
+++ b/component/org.wso2.carbon.identity.api.otp.service.smsotp/src/main/java/org/wso2/carbon/identity/api/otp/service/smsotp/utill/EndpointUtils.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.identity.api.otp.service.smsotp.utill;
 
 import org.apache.commons.logging.Log;
-import org.apache.log4j.MDC;
+import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.api.otp.service.smsotp.dto.Error;
 import org.wso2.carbon.identity.api.otp.service.smsotp.exception.BadRequestException;


### PR DESCRIPTION
- Change log4j imports to slf4j so that the otp integration endpoints work with the latest WSO2 Identity Server 5.11.0.